### PR TITLE
feat(assertions): Mocking 클래스 추가

### DIFF
--- a/src/main/java/camp/nextstep/edu/missionutils/Mocking.java
+++ b/src/main/java/camp/nextstep/edu/missionutils/Mocking.java
@@ -1,0 +1,58 @@
+package camp.nextstep.edu.missionutils;
+
+import org.mockito.MockedStatic;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+
+public class Mocking<T> {
+
+    /**
+     * stubbing lambda verification
+     * 예시)
+     * () -> Randoms.pickNumberInList(anyList())
+     */
+    private final MockedStatic.Verification verification;
+
+    // 반환할 첫 번째 값
+    private final T value;
+
+    /**
+     * 첫 번째 값을 반환하고 나서 다음에 반환할 값들.
+     * 예를 들면, verification을 처음 실행하면 value를 반환하고
+     * 두 번째 실행하면 values[0]을 반환한다.
+     */
+    private final T[] values;
+
+    private Mocking(final MockedStatic.Verification verification,
+                    final T value,
+                    final T... values) {
+        this.verification = verification;
+        this.value = value;
+        this.values = values;
+    }
+
+    // enum으로 빼도 괜찮을 것 같은데..?
+    public static Mocking<Integer> ofRandomNumberInList(final Integer value, final Integer... values) {
+        return new Mocking<>(() -> Randoms.pickNumberInList(anyList()), value, values);
+    }
+
+    public static Mocking<Integer> ofRandomNumberInRange(final Integer value, final Integer... values) {
+        return new Mocking<>(() -> Randoms.pickNumberInRange(anyInt(), anyInt()), value, values);
+    }
+
+    public static Mocking<List<Integer>> ofRandomUniqueNumbersInRange(final List<Integer> value, final List<Integer>... values) {
+        return new Mocking<>(() -> Randoms.pickUniqueNumbersInRange(anyInt(), anyInt(), anyInt()), value, values);
+    }
+
+    public static <T> Mocking<List<T>> ofShuffle(final List<T> value, final List<T>... values) {
+        return new Mocking<>(() -> Randoms.shuffle(anyList()), value, values);
+    }
+
+    public <S> void stub(final MockedStatic<S> mock) {
+        mock.when(verification).thenReturn(value, Arrays.stream(values).toArray());
+    }
+}

--- a/src/main/java/camp/nextstep/edu/missionutils/test/Assertions.java
+++ b/src/main/java/camp/nextstep/edu/missionutils/test/Assertions.java
@@ -1,5 +1,6 @@
 package camp.nextstep.edu.missionutils.test;
 
+import camp.nextstep.edu.missionutils.Mocking;
 import camp.nextstep.edu.missionutils.Randoms;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.MockedStatic;
@@ -9,9 +10,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.MockedStatic.Verification;
 import static org.mockito.Mockito.mockStatic;
 
 public class Assertions {
@@ -30,12 +28,7 @@ public class Assertions {
         final Integer value,
         final Integer... values
     ) {
-        assertRandomTest(
-            () -> Randoms.pickNumberInList(anyList()),
-            executable,
-            value,
-            values
-        );
+        assertRandomTest(executable, Mocking.ofRandomNumberInList(value, values));
     }
 
     public static void assertRandomNumberInRangeTest(
@@ -43,49 +36,34 @@ public class Assertions {
         final Integer value,
         final Integer... values
     ) {
-        assertRandomTest(
-            () -> Randoms.pickNumberInRange(anyInt(), anyInt()),
-            executable,
-            value,
-            values
-        );
+        assertRandomTest(executable, Mocking.ofRandomNumberInRange(value, values));
     }
 
+    @SafeVarargs
     public static void assertRandomUniqueNumbersInRangeTest(
         final Executable executable,
         final List<Integer> value,
         final List<Integer>... values
     ) {
-        assertRandomTest(
-            () -> Randoms.pickUniqueNumbersInRange(anyInt(), anyInt(), anyInt()),
-            executable,
-            value,
-            values
-        );
+        assertRandomTest(executable, Mocking.ofRandomUniqueNumbersInRange(value, values));
     }
 
+    @SafeVarargs
     public static <T> void assertShuffleTest(
         final Executable executable,
         final List<T> value,
         final List<T>... values
     ) {
-        assertRandomTest(
-            () -> Randoms.shuffle(anyList()),
-            executable,
-            value,
-            values
-        );
+        assertRandomTest(executable, Mocking.ofShuffle(value, values));
     }
 
-    private static <T> void assertRandomTest(
-        final Verification verification,
-        final Executable executable,
-        final T value,
-        final T... values
+    public static void assertRandomTest(
+            final Executable executable,
+            final Mocking... mockings
     ) {
         assertTimeoutPreemptively(RANDOM_TEST_TIMEOUT, () -> {
             try (final MockedStatic<Randoms> mock = mockStatic(Randoms.class)) {
-                mock.when(verification).thenReturn(value, Arrays.stream(values).toArray());
+                Arrays.stream(mockings).forEach(mocking -> mocking.stub(mock));
                 executable.execute();
             }
         });


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

- Randoms 클래스의 정적 메서드를 1개 이상 stubbing 할 수 있도록 수정
- 코드 정리

# 어떻게 해결했나요?

- Mocking 클래스를 추가하여 verification, value, values를 하나로 묶음
- assertRandomTest를 public으로 열어서 사용자가 Mocking를 활용하여 랜덤 메서드를 직접 지정해서 stubbing하도록 유연성 제공

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 라이브러리 사용자에게 Mocking 클래스를 제공하는게 좋을지, 적절한 설계인지 의견 부탁드려요.
- Assertions 클래스에서 기존 로직과 큰 차이가 없다고 생각하여 `@SafeVarargs`를 붙인 메서드가 문제 없을지 크로스 체크 부탁드립니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
