### PR TITLE
fix(mission-utils): close the console after the test

### DIFF
--- a/src/main/java/camp/nextstep/edu/missionutils/Console.java
+++ b/src/main/java/camp/nextstep/edu/missionutils/Console.java
@@ -1,7 +1,6 @@
 package camp.nextstep.edu.missionutils;
 
 import java.lang.reflect.Field;
-import java.util.Objects;
 import java.util.Scanner;
 
 public class Console {
@@ -14,8 +13,14 @@ public class Console {
         return getInstance().nextLine();
     }
 
+    public static void close() {
+        if (scanner != null) {
+            scanner.close();
+        }
+    }
+
     private static Scanner getInstance() {
-        if (Objects.isNull(scanner) || isClosed()) {
+        if (scanner == null || isClosed()) {
             scanner = new Scanner(System.in);
         }
         return scanner;

--- a/src/main/java/camp/nextstep/edu/missionutils/test/NsTest.java
+++ b/src/main/java/camp/nextstep/edu/missionutils/test/NsTest.java
@@ -1,5 +1,6 @@
 package camp.nextstep.edu.missionutils.test;
 
+import camp.nextstep.edu.missionutils.Console;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -39,6 +40,8 @@ public abstract class NsTest {
         try {
             run(args);
         } catch (final NoSuchElementException ignore) {
+        } finally {
+            Console.close();
         }
     }
 

--- a/src/main/java/camp/nextstep/edu/missionutils/test/NsTest.java
+++ b/src/main/java/camp/nextstep/edu/missionutils/test/NsTest.java
@@ -32,16 +32,18 @@ public abstract class NsTest {
     }
 
     protected final void run(final String... args) {
-        command(args);
-        runMain();
+        try {
+            command(args);
+            runMain();
+        } finally {
+            Console.close();
+        }
     }
 
     protected final void runException(final String... args) {
         try {
             run(args);
         } catch (final NoSuchElementException ignore) {
-        } finally {
-            Console.close();
         }
     }
 

--- a/src/test/java/camp/nextstep/edu/missionutils/acceptance/ScannerBufferTest.java
+++ b/src/test/java/camp/nextstep/edu/missionutils/acceptance/ScannerBufferTest.java
@@ -2,7 +2,13 @@ package camp.nextstep.edu.missionutils.acceptance;
 
 import camp.nextstep.edu.missionutils.Console;
 import camp.nextstep.edu.missionutils.test.NsTest;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import static camp.nextstep.edu.missionutils.test.Assertions.assertSimpleTest;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;

--- a/src/test/java/camp/nextstep/edu/missionutils/acceptance/ScannerBufferTest.java
+++ b/src/test/java/camp/nextstep/edu/missionutils/acceptance/ScannerBufferTest.java
@@ -2,35 +2,61 @@ package camp.nextstep.edu.missionutils.acceptance;
 
 import camp.nextstep.edu.missionutils.Console;
 import camp.nextstep.edu.missionutils.test.NsTest;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 
 import static camp.nextstep.edu.missionutils.test.Assertions.assertSimpleTest;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-@TestMethodOrder(MethodOrderer.MethodName.class)
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
 class ScannerBufferTest extends NsTest {
     private static final String ERROR_CAUSING_MESSAGE = "ERROR";
     private static final String NORMAL_MESSAGE = "MESSAGE";
 
-    @Test
-    void test1() {
-        assertSimpleTest(() ->
-            assertThatIllegalArgumentException().isThrownBy(() ->
-                runException(ERROR_CAUSING_MESSAGE, ERROR_CAUSING_MESSAGE)
-            )
-        );
+    @Order(1)
+    @TestMethodOrder(MethodOrderer.MethodName.class)
+    @Nested
+    class RunExceptionTest {
+        @Test
+        void test1() {
+            assertSimpleTest(() ->
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                    runException(ERROR_CAUSING_MESSAGE, ERROR_CAUSING_MESSAGE)
+                )
+            );
+        }
+
+        @Test
+        void test2() {
+            assertSimpleTest(() ->
+                assertThatNoException().isThrownBy(() ->
+                    run(NORMAL_MESSAGE)
+                )
+            );
+        }
     }
 
-    @Test
-    void test2() {
-        assertSimpleTest(() ->
-            assertThatNoException().isThrownBy(() ->
-                run(NORMAL_MESSAGE)
-            )
-        );
+    @Order(2)
+    @TestMethodOrder(MethodOrderer.MethodName.class)
+    @Nested
+    class RunTest {
+        @Test
+        void test1() {
+            assertSimpleTest(() ->
+                assertThatNoException().isThrownBy(() ->
+                    run(NORMAL_MESSAGE, ERROR_CAUSING_MESSAGE)
+                )
+            );
+        }
+
+        @Test
+        void test2() {
+            assertSimpleTest(() ->
+                assertThatNoException().isThrownBy(() ->
+                    run(NORMAL_MESSAGE)
+                )
+            );
+        }
     }
 
     @Override

--- a/src/test/java/camp/nextstep/edu/missionutils/acceptance/ScannerBufferTest.java
+++ b/src/test/java/camp/nextstep/edu/missionutils/acceptance/ScannerBufferTest.java
@@ -1,0 +1,43 @@
+package camp.nextstep.edu.missionutils.acceptance;
+
+import camp.nextstep.edu.missionutils.Console;
+import camp.nextstep.edu.missionutils.test.NsTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static camp.nextstep.edu.missionutils.test.Assertions.assertSimpleTest;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+class ScannerBufferTest extends NsTest {
+    private static final String ERROR_CAUSING_MESSAGE = "ERROR";
+    private static final String NORMAL_MESSAGE = "MESSAGE";
+
+    @Test
+    void test1() {
+        assertSimpleTest(() ->
+            assertThatIllegalArgumentException().isThrownBy(() ->
+                runException(ERROR_CAUSING_MESSAGE, ERROR_CAUSING_MESSAGE)
+            )
+        );
+    }
+
+    @Test
+    void test2() {
+        assertSimpleTest(() ->
+            assertThatNoException().isThrownBy(() ->
+                run(NORMAL_MESSAGE)
+            )
+        );
+    }
+
+    @Override
+    protected void runMain() {
+        final String input = Console.readLine();
+        if (input.contains(ERROR_CAUSING_MESSAGE)) {
+            throw new IllegalArgumentException("An error occurred because of this phrase: " + input);
+        }
+    }
+}

--- a/src/test/java/camp/nextstep/edu/missionutils/acceptance/ScannerBufferTest.java
+++ b/src/test/java/camp/nextstep/edu/missionutils/acceptance/ScannerBufferTest.java
@@ -2,24 +2,19 @@ package camp.nextstep.edu.missionutils.acceptance;
 
 import camp.nextstep.edu.missionutils.Console;
 import camp.nextstep.edu.missionutils.test.NsTest;
-import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import static camp.nextstep.edu.missionutils.test.Assertions.assertSimpleTest;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-@TestClassOrder(ClassOrderer.OrderAnnotation.class)
 class ScannerBufferTest extends NsTest {
     private static final String ERROR_CAUSING_MESSAGE = "ERROR";
     private static final String NORMAL_MESSAGE = "MESSAGE";
 
-    @Order(1)
     @TestMethodOrder(MethodOrderer.MethodName.class)
     @Nested
     class RunExceptionTest {
@@ -42,7 +37,6 @@ class ScannerBufferTest extends NsTest {
         }
     }
 
-    @Order(2)
     @TestMethodOrder(MethodOrderer.MethodName.class)
     @Nested
     class RunTest {

--- a/src/test/java/camp/nextstep/edu/missionutils/test/AssertionsTest.java
+++ b/src/test/java/camp/nextstep/edu/missionutils/test/AssertionsTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static camp.nextstep.edu.missionutils.test.Assertions.*;
+import static camp.nextstep.edu.missionutils.test.Assertions.assertRandomNumberInRangeTest;
+import static camp.nextstep.edu.missionutils.test.Assertions.assertRandomUniqueNumbersInRangeTest;
+import static camp.nextstep.edu.missionutils.test.Assertions.assertShuffleTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AssertionsTest {


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

- 콘솔 입출력 중 예외에 대한 테스트를 실행할 때, 예외가 발생한 후 전역적으로 사용되는 `Scanner`에 남아 있는 버퍼가 다른 테스트에 영향을 미치고 있습니다.

# 어떻게 해결했나요?

- 콘솔 입출력을 테스트할 때는 `Scanner`에서 `close()`를 명시적으로 호출하여 `Scanner` 내부의 `source`를 비웁니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 문제를 재현할 수 있는 간단한 테스트를 추가했는데, 추가 사례가 있으면 알려 주세요.
- 예외를 테스트할 때뿐만 아니라 정상 상황을 테스트할 때의 실수도 방지했는데 오버엔지니어링일까요?
- @woowahan-neo 한 명의 지원자의 경우 테스트가 병렬로 실행되지 않기 때문에 문제가 없을 것으로 생각합니다. 서버에서 여러 지원자에 대한 테스트 코드를 동시에 실행했을 때 문제가 없는지 확인해 주시면 감사합니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
