### PR TITLE
refactor(mission-utils): remove illegal reflective access after java 9

### DIFF
--- a/src/main/java/camp/nextstep/edu/missionutils/Console.java
+++ b/src/main/java/camp/nextstep/edu/missionutils/Console.java
@@ -1,6 +1,5 @@
 package camp.nextstep.edu.missionutils;
 
-import java.lang.reflect.Field;
 import java.util.Scanner;
 
 public class Console {
@@ -16,24 +15,14 @@ public class Console {
     public static void close() {
         if (scanner != null) {
             scanner.close();
+            scanner = null;
         }
     }
 
     private static Scanner getInstance() {
-        if (scanner == null || isClosed()) {
+        if (scanner == null) {
             scanner = new Scanner(System.in);
         }
         return scanner;
-    }
-
-    private static boolean isClosed() {
-        try {
-            final Field sourceClosedField = Scanner.class.getDeclaredField("sourceClosed");
-            sourceClosedField.setAccessible(true);
-            return sourceClosedField.getBoolean(scanner);
-        } catch (final Exception e) {
-            System.out.println("unable to determine if the scanner is closed.");
-        }
-        return true;
     }
 }


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

- 보안 및 캡슐화를 개선하기 위한 모듈 시스템의 등장으로 Java 9 이후에는 아래 경고가 나타납니다.

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by camp.nextstep.edu.missionutils.Console (file:/mission-utils/build/classes/java/main/) to field java.util.Scanner.sourceClosed
WARNING: Please consider reporting this to the maintainers of camp.nextstep.edu.missionutils.Console
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

- 이 경고는 Reflection API을 사용하여 `java.util.Scanner`의 `sourceClosed` 필드에 접근할 때 나타납니다. Java 16에서는 `--illegal-access` 옵션을 변경해야 하며, Java 17 이후에는 완전히 접근할 수 없게 됩니다.

# 어떻게 해결했나요?

- `Scanner`를 재사용하기 위해 Reflection API를 사용하여 `sourceClosed` 값을 가져오는 대신 `close()`를 호출한 후 무조건 새 `Scanner`를 생성하도록 변경했습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 과거에는 사용자가 `Scanner`를 전역으로 선언하면 한 번의 테스트 후에 `Scanner`가 자동으로 종료되어 다음 테스트에서는 사용할 수 없어 `sourceClosed` 값을 확인하는 함수를 구현했습니다. 이제 `Console`을 사용하고 있으니, 걱정은 없지만 혹시 놓친 부분이 있는지 궁금합니다.
- @woowahan-neo 한 명의 지원자의 경우 테스트가 병렬로 실행되지 않기 때문에 문제가 없을 것으로 생각합니다. 서버에서 여러 지원자에 대한 테스트 코드를 동시에 실행했을 때 문제가 없는지 확인해 주시면 감사합니다.

## 참고 자료

- https://www.baeldung.com/java-illegal-reflective-access

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
